### PR TITLE
haxe.io.Bytes based Aseprite class

### DIFF
--- a/aseprite/Aseprite.hx
+++ b/aseprite/Aseprite.hx
@@ -15,7 +15,7 @@ import hxd.Pixels;
 import hxd.fs.FileEntry;
 import hxd.res.Resource;
 
-class Aseprite extends Resource {
+class Aseprite {
   public var ase:Ase;
   public var frames(default, null):Array<Frame> = [];
   public var layers(default, null):Array<LayerChunk> = [];
@@ -30,9 +30,8 @@ class Aseprite extends Resource {
   var widthInTiles:Int;
   var heightInTiles:Int;
 
-  public function new(entry:FileEntry) {
-    super(entry);
-    loadData();
+  public function new(bytes:haxe.io.Bytes) {
+    fromBytes(bytes);
   }
 
   public function toTexture():Texture {
@@ -183,19 +182,24 @@ class Aseprite extends Resource {
     ];
   }
 
-  public function watchCallback() {
+  // public function watchCallback() { // not supported
+  //   dispose();
+  //   loadData();
+  //   loadTexture();
+  // }
+
+  function dispose() {
     for (frame in frames) frame.dispose();
     frames.resize(0);
     layers.resize(0);
     tags.clear();
     slices.clear();
     tiles = null;
-    loadData();
-    loadTexture();
   }
 
-  function loadData() {
-    ase = Ase.fromBytes(entry.getBytes());
+  public function fromBytes(bytes:haxe.io.Bytes) {
+    dispose();
+    ase = Ase.fromBytes(bytes);
 
     for (chunk in ase.frames[0].chunks) {
       switch (chunk.header.type) {
@@ -272,7 +276,7 @@ class Aseprite extends Resource {
 
     if (texture == null) {
       texture = Texture.fromPixels(pixels);
-      watch(watchCallback);
+      // watch(watchCallback); // not supported
     }
     else {
       var t = Texture.fromPixels(pixels);

--- a/aseprite/AsepriteRes.hx
+++ b/aseprite/AsepriteRes.hx
@@ -1,0 +1,16 @@
+package aseprite;
+
+import hxd.fs.FileEntry;
+import hxd.res.Resource;
+
+class AsepriteRes extends Resource {
+
+  public function new(entry:FileEntry) {
+    super(entry);
+  }
+
+  /** Create an Aseprite instance from this resource **/
+  public inline function toAseprite() : Aseprite {
+    return new Aseprite( entry.getBytes() );
+  }
+}

--- a/aseprite/Macros.hx
+++ b/aseprite/Macros.hx
@@ -3,8 +3,8 @@ package aseprite;
 class Macros {
   #if macro
   public static function init() {
-    hxd.res.Config.extensions.set('aseprite', 'aseprite.Aseprite');
-    hxd.res.Config.extensions.set('ase', 'aseprite.Aseprite');
+    hxd.res.Config.extensions.set('aseprite', 'aseprite.AsepriteRes');
+    hxd.res.Config.extensions.set('ase', 'aseprite.AsepriteRes');
   }
   #end
 }


### PR DESCRIPTION
Aseprite is now based on `haxe.io.Bytes` and no longer tied to Heaps resource system

Added separate resource class: `aseprite.AsepriteRes`

**USAGE**
```haxe
var myAseprite = hxd.Res.myFile.toAseprite(); // previously: hxd.Res.myFile
```

The only downside is that you have to let the user take care of *hot-reloading* stuff (ie. file watching). But IMHO that's safer actually, as swapping the texture without notifying the user on file change will lead to issues on runtime anyway 🤔 

It's still possible to "refresh" a Aseprite instance using the public `myAseprite.fromBytes( bytes:haxe.io.Bytes )` method 👍 