### PR TITLE
Made loaded image resizing optional (disabled by default)

### DIFF
--- a/aseprite/Aseprite.hx
+++ b/aseprite/Aseprite.hx
@@ -16,6 +16,9 @@ import hxd.fs.FileEntry;
 import hxd.res.Resource;
 
 class Aseprite extends Resource {
+  /** This option should be set before loading any texture **/
+  public static var resizeToNextPowerOfTwo = false;
+
   public var ase:Ase;
   public var frames(default, null):Array<Frame> = [];
   public var layers(default, null):Array<LayerChunk> = [];
@@ -259,8 +262,12 @@ class Aseprite extends Resource {
       }
     }
 
-    var textureWidth = next_power_of_2(ase.header.width * widthInTiles);
-    var textureHeight = next_power_of_2(ase.header.height * heightInTiles);
+    var textureWidth = ase.header.width * widthInTiles;
+    var textureHeight = ase.header.height * heightInTiles;
+    if( resizeToNextPowerOfTwo ) {
+      textureWidth = next_power_of_2(textureWidth);
+      textureHeight = next_power_of_2(textureHeight);
+    }
 
     var pixels = Pixels.alloc(textureWidth, textureHeight, RGBA);
 


### PR DESCRIPTION
Added a static option to enable texture resizing. It's disabled by default to avoid unexpected results from the user perspective.

# Alternative 

Another possible approach is to let the resizing as it is, but 

1. make sure that some warnings & doc explain what happens behind the scene
2. fix `toTile()` (and maybe other places) to hide the optimization tweak and make it 100% transparent for the dev. 

# Why this change? 

When creating the Heaps Texture from an aseprite file, you change its width/height to their "next power of 2". 

Even if I understand the reason behind, this can be misleading as the resulting object has a different size as the source file :thinking:  This is a problem if the dev (eg. me with LDtk) wanted to use the Aseprite file as a tileset

Also, it's a bit strange to just load an Aseprite, trace() its width/height, and get a different value from the real Aseprite file.